### PR TITLE
FIX: counter of histogram calculate mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /.gradle/
 /build/
 
+client-jvm.iml
+
 # Maven
 /target/
 

--- a/src/main/java/io/victoriametrics/client/metrics/Histogram.java
+++ b/src/main/java/io/victoriametrics/client/metrics/Histogram.java
@@ -88,9 +88,13 @@ public class Histogram implements Metric {
                 upper++;
             } else {
                 int index = (int) bucketIndex;
-                int decimalBucketIndex = index / BUCKETS_PER_DECIMAL;
-                int offset = index % BUCKETS_PER_DECIMAL;
-                buckets[decimalBucketIndex * offset]++;
+                if (bucketIndex == (double)(index) && index > 0) {
+                    // Edge case for 10^n values, which must go to the lower bucket
+                    // according to Prometheus logic for `le`-based histograms.
+                    // -- from github.com/VictoriaMetrics/metrics v1.18.1
+                    index--;
+                }
+                buckets[index]++;
             }
         } finally {
             mutex.unlock();

--- a/src/main/java/io/victoriametrics/client/serialization/PrometheusSerializationStrategy.java
+++ b/src/main/java/io/victoriametrics/client/serialization/PrometheusSerializationStrategy.java
@@ -87,7 +87,7 @@ public class PrometheusSerializationStrategy implements SerializationStrategy {
                 throw new MetricSerializationException("Unable to serialize Histogram metric: " + prefix, e);
             }
 
-            countTotal.increment();
+            countTotal.add(count);
         });
 
         Pair<String, String> metricPair = splitMetricName(prefix);

--- a/src/main/java/io/victoriametrics/client/serialization/PrometheusSerializationStrategy.java
+++ b/src/main/java/io/victoriametrics/client/serialization/PrometheusSerializationStrategy.java
@@ -80,7 +80,7 @@ public class PrometheusSerializationStrategy implements SerializationStrategy {
                 writer.write("_bucket");
                 writer.write("{");
                 writer.write(labels);
-                writer.write("}");
+                writer.write("} ");
                 writer.write(Double.toString(count));
                 writer.write("\n");
             }  catch (IOException e) {


### PR DESCRIPTION
There is a bug that the counter in histogram is add with the number of buckets. That is a mistake.
The right way is add with the value of buckets.