### PR TITLE
Expose metrics through spring boot actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 
 # Java lightweight library for exporting metrics in Prometheus format
 
+### Install 
+
+Checkout the repository and install to local Maven repository.
+
+```shell
+./mvnw install
+```
+
+Add dependecy in to your pom.xml
+
+```xml
+<dependency>
+    <groupId>io.victoriametrics.client</groupId>
+    <artifactId>metrics</artifactId>
+    <version>1.0-SNAPSHOT</version>
+</dependency>
+```
+
 ### Usage
 
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>metrics</module>
         <module>httpserver</module>
         <module>benchmarks</module>
+        <module>springboot</module>
     </modules>
 
     <build>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Victoria Metrics Inc.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>io.victoriametrics.client</groupId>
+        <version>1.0-SNAPSHOT</version>
+        <artifactId>parent</artifactId>
+    </parent>
+
+    <artifactId>springboot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <jvm.modules>java.logging</jvm.modules>
+        <junit.version>5.9.1</junit.version>
+
+        <spring.boot.version>2.7.13</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.victoriametrics.client</groupId>
+            <artifactId>metrics</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/springboot/src/main/java/io/victoriametrics/client/springboot/EnableVictoriaMetricsEndpoint.java
+++ b/springboot/src/main/java/io/victoriametrics/client/springboot/EnableVictoriaMetricsEndpoint.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Victoria Metrics Inc.
+ */
+
+package io.victoriametrics.client.springboot;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * @author Valery Kantor
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(VictoriaMetricsEndpointConfiguration.class)
+public @interface EnableVictoriaMetricsEndpoint {
+}

--- a/springboot/src/main/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpoint.java
+++ b/springboot/src/main/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpoint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Victoria Metrics Inc.
+ */
+
+package io.victoriametrics.client.springboot;
+
+import io.victoriametrics.client.metrics.MetricRegistry;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.io.StringWriter;
+
+
+/**
+ * @Endpoint to expose metrics.
+ *
+ * @author Valery Kantor
+ */
+@Endpoint(id = "victoriametrics")
+public class VictoriaMetricsEndpoint {
+
+    private final MetricRegistry metricRegistry;
+
+    public VictoriaMetricsEndpoint(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @ReadOperation
+    public String metrics() {
+        StringWriter writer = new StringWriter();
+        metricRegistry.write(writer);
+        return writer.toString();
+    }
+}

--- a/springboot/src/main/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpointConfiguration.java
+++ b/springboot/src/main/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpointConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Victoria Metrics Inc.
+ */
+
+package io.victoriametrics.client.springboot;
+
+import io.victoriametrics.client.metrics.MetricRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Valery Kantor
+ */
+@Configuration
+public class VictoriaMetricsEndpointConfiguration {
+
+    @Bean
+    public VictoriaMetricsEndpoint victoriaMetricsEndpoint(MetricRegistry metricRegistry) {
+        return new VictoriaMetricsEndpoint(metricRegistry);
+    }
+
+    @Bean
+    public MetricRegistry metricRegistry() {
+        return MetricRegistry.create();
+    }
+}

--- a/springboot/src/test/java/io/victoriametrics/client/springboot/TestApplication.java
+++ b/springboot/src/test/java/io/victoriametrics/client/springboot/TestApplication.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Victoria Metrics Inc.
+ */
+
+package io.victoriametrics.client.springboot;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Valery Kantor
+ */
+@SpringBootApplication
+public class TestApplication {
+}

--- a/springboot/src/test/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpointTest.java
+++ b/springboot/src/test/java/io/victoriametrics/client/springboot/VictoriaMetricsEndpointTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Victoria Metrics Inc.
+ */
+
+package io.victoriametrics.client.springboot;
+
+import io.victoriametrics.client.metrics.Counter;
+import io.victoriametrics.client.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Valery Kantor
+ */
+@EnableVictoriaMetricsEndpoint
+@EnableAutoConfiguration
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@TestPropertySource(properties = {
+        "management.endpoint.victoriametrics.enabled=true",
+        "management.endpoints.web.exposure.include=victoriametrics",
+        "management.port=0"
+})
+@AutoConfigureMockMvc
+class VictoriaMetricsEndpointTest {
+
+    @Autowired
+    TestRestTemplate template;
+
+    @LocalServerPort
+    int localServerPort;
+
+    @Autowired
+    MetricRegistry metricRegistry;
+
+    @LocalManagementPort
+    int menagementPort;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void test_metrics_export() throws Exception {
+        Counter counter = metricRegistry.createCounter()
+                                        .name("foo")
+                                        .addLabel("label1", "bar")
+                                        .register();
+
+        counter.inc();
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/actuator/victoriametrics"))
+               .andExpect(status().isOk())
+               .andExpect(content().string("foo{label1=\"bar\"} 1\n"));
+    }
+
+}

--- a/springboot/src/test/resources/application.yml
+++ b/springboot/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+
+logging:
+  level:
+    org.springframework: DEBUG


### PR DESCRIPTION
The module allows exposing metrics through the Spring Boot actuator in a Spring Boot project.
To make the configuration works you just need to add **@EnableVictoriaMetricsEndpoint** annotation in your project configuration and add "victoriametrics" to the list of endpoints exposure like:
**management.endpoints.web.exposure.include=victoriametrics, health** in the application.properties or application.yml