### PR TITLE
Summary: fix nanos and change to Duration

### DIFF
--- a/metrics/src/main/java/io/victoriametrics/client/metrics/MetricRegistry.java
+++ b/metrics/src/main/java/io/victoriametrics/client/metrics/MetricRegistry.java
@@ -5,6 +5,7 @@ import io.victoriametrics.client.serialization.SerializationStrategy;
 import io.victoriametrics.client.validator.MetricNameValidator;
 
 import java.io.Writer;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -123,16 +124,16 @@ public final class MetricRegistry {
      * @param name A metric name
      * @return {@link Histogram} if metric name is valid.
      */
-    public Summary getOrCreateSummary(String name, double[] quantiles, int windows, long windowDurationSeconds) {
+    public Summary getOrCreateSummary(String name, double[] quantiles, int windows, Duration window) {
         return (Summary) collection.computeIfAbsent(name, key-> {
             validator.validate(key);
-            return new Summary(key, quantiles, windows, windowDurationSeconds);
+            return new Summary(key, quantiles, window, windows);
         });
     }
 
     /**
-     * Write metricts
-     * @param writer
+     * Serialize metric values according to {@link #serializationStrategy}
+     * @param writer destination
      */
     public void write(Writer writer) {
         Collection<Metric> metrics = collection.values();

--- a/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
+++ b/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
@@ -44,7 +44,8 @@ public class Summary implements Metric {
 
     private void validateQuantiles(double[] quantiles) {
         for (double quantile : quantiles) {
-            if (quantile < 0.0 || quantile > 1.0 ) throw new IllegalArgumentException("Quantile must be in range 0 and 1");
+            if (quantile < 0.0 || quantile > 1.0 )
+                throw new IllegalArgumentException("Quantile must be between 0.0 and 1.0");
         }
     }
 
@@ -150,7 +151,7 @@ public class Summary implements Metric {
         }
 
         public double get(double phi) {
-            if (samples.size() == 0) {
+            if (samples.isEmpty()) {
                 return Double.NaN;
             }
 

--- a/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
+++ b/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
@@ -30,7 +30,7 @@ public class Summary implements Metric {
 
     private final DoubleAdder sum = new DoubleAdder();
 
-    private final TimeWindowQuantile timeWindowQuantile;
+    final TimeWindowQuantile timeWindowQuantile;
 
     public Summary(String name) {
         this(name, DEFAULT_QUANTILES, DEFAULT_MAX_AGE, DEFAULT_AGE_BUCKETS);
@@ -94,17 +94,17 @@ public class Summary implements Metric {
         visitor.visit(this);
     }
 
-    private static class TimeWindowQuantile {
-        private final TimeWindow[] timeWindow;
+    static class TimeWindowQuantile {
+        final TimeWindow[] timeWindow;
 
-        private final long rotationDurationMillis;
+        final long rotationDurationMillis;
 
         /**
          * The last rotation timestamp in nanos
          */
-        private long lastRotationTimestamp;
+        long lastRotationTimestamp;
 
-        private int currentWindow = 0;
+        int currentWindow = 0;
 
         private TimeWindowQuantile(Duration window, int timeWindows) {
             this.timeWindow = new TimeWindow[timeWindows];

--- a/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
+++ b/metrics/src/main/java/io/victoriametrics/client/metrics/Summary.java
@@ -136,7 +136,7 @@ public class Summary implements Metric {
                 }
 
                 elapsedFromLastRotation -= rotationDurationMillis;
-                lastRotationTimestamp += rotationDurationMillis;
+                lastRotationTimestamp += rotationDurationMillis * 1000_000;
             }
 
             return timeWindow[currentWindow];

--- a/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
+++ b/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
@@ -46,8 +46,8 @@ public class SummaryTest {
             summary.update(123 + i);
         }
 
-        // Wait for window update and verify that the summary has been cleared.
-        Thread.sleep(window.multipliedBy(2).toMillis());
+        Summary.TimeWindowQuantile quantile = summary.timeWindowQuantile;
+        quantile.lastRotationTimestamp -= quantile.rotationDurationMillis * 1000_000;
 
         assertEquals(Double.NaN, summary.getQuantile(0.1));
         assertEquals(Double.NaN, summary.getQuantile(0.2));

--- a/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
+++ b/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
@@ -47,7 +47,7 @@ public class SummaryTest {
         }
 
         Summary.TimeWindowQuantile quantile = summary.timeWindowQuantile;
-        quantile.lastRotationTimestamp -= quantile.rotationDurationMillis * 1000_000;
+        quantile.lastRotationNs -= quantile.rotateEachNs;
 
         assertEquals(Double.NaN, summary.getQuantile(0.1));
         assertEquals(Double.NaN, summary.getQuantile(0.2));

--- a/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
+++ b/metrics/src/test/java/io/victoriametrics/client/metrics/SummaryTest.java
@@ -6,7 +6,7 @@ package io.victoriametrics.client.metrics;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -37,17 +37,18 @@ public class SummaryTest {
 
     @Test
     public void testSummarySmallWindow() throws InterruptedException {
-        double[] quantiles = new double[] {0.1, 0.2, 0.3};
-        long windowDurationSeconds = 5;
+        double[] quantiles = new double[]{0.1, 0.2, 0.3};
         MetricRegistry collection = MetricRegistry.create();
-        final Summary summary = collection.getOrCreateSummary("SmallWindow", quantiles, 2, windowDurationSeconds);
+        Duration window = Duration.ofSeconds(5);
+        Summary summary = collection.getOrCreateSummary("SmallWindow", quantiles, 2, window);
 
         for (int i = 0; i < 10000; i++) {
-            summary.update(123);
+            summary.update(123 + i);
         }
 
         // Wait for window update and verify that the summary has been cleared.
-        Thread.sleep(2 * TimeUnit.SECONDS.toMillis(windowDurationSeconds));
+        Thread.sleep(window.multipliedBy(2).toMillis());
+
         assertEquals(Double.NaN, summary.getQuantile(0.1));
         assertEquals(Double.NaN, summary.getQuantile(0.2));
         assertEquals(Double.NaN, summary.getQuantile(0.3));


### PR DESCRIPTION
Fix #32 
For readability, used `java.util.Duration` for window length for metric creation.